### PR TITLE
added player's weapon color to the proxy input list

### DIFF
--- a/lua/pac3/core/client/parts/proxy.lua
+++ b/lua/pac3/core/client/parts/proxy.lua
@@ -511,6 +511,42 @@ PART.Inputs =
 
 		return (b - a) * m + a
 	end,
+	
+	weapon_color_r = function(self)
+		local owner = self:GetPlayerOwner()
+		
+		if owner:IsValid() then
+			local vec = owner:GetWeaponColor()
+			
+			return vec.r
+		end
+		
+		return 1
+	end,
+	
+	weapon_color_g = function(self)
+		local owner = self:GetPlayerOwner()
+		
+		if owner:IsValid() then
+			local vec = owner:GetWeaponColor()
+			
+			return vec.g
+		end
+		
+		return 1
+	end, 
+	
+	weapon_color_b = function(self)
+		local owner = self:GetPlayerOwner()
+		
+		if owner:IsValid() then
+			local vec = owner:GetWeaponColor()
+			
+			return vec.b 
+		end 
+		
+		return 1 
+	end, 
 }
 
 usermessage.Hook("pac_proxy", function(umr)


### PR DESCRIPTION
if we can set parts to use the weapon color by checking the checkbox, why can't we set the weapon color with proxies, but we can do both with the player color? or is it because of some strange security reason I'm not aware of?